### PR TITLE
client: include model parameters from request when specified

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -29,8 +29,11 @@ func main() {
 		workersai.ChatMessage{Role: "user", Content: "Why is pizza so good?"},
 	}
 
+	p := workersai.ModelParameters{
+		Temperature: 0.1,
+	}
 	// Using a known model from the library constants
-	chatResponse, err := client.Chat(workersai.ModelQwen330ba3b, chatMessages)
+	chatResponse, err := client.Chat(workersai.ModelQwen330ba3b, chatMessages, &p)
 	if err != nil {
 		log.Printf("Error sending chat request: %v", err)
 	} else {
@@ -86,7 +89,7 @@ func main() {
 		workersai.ChatMessage{Role: "user", Content: "What's the weather like in San Francisco?"},
 	}
 
-	toolResponse, err := client.ChatWithTools(workersai.ModelQwen330ba3b, toolMessages, tools)
+	toolResponse, err := client.ChatWithTools(workersai.ModelQwen330ba3b, toolMessages, tools, nil)
 	if err != nil {
 		log.Printf("Error sending tool calling request: %v", err)
 	} else {

--- a/workers-ai/client.go
+++ b/workers-ai/client.go
@@ -43,11 +43,11 @@ func (c *Client) SetDebug(debug bool) {
 	c.Debug = debug
 }
 
-func (c *Client) Chat(modelID string, messages []Message) (*ChatResponse, error) {
-	return c.ChatWithTools(modelID, messages, nil)
+func (c *Client) Chat(modelID string, messages []Message, modelParams *ModelParameters) (*ChatResponse, error) {
+	return c.ChatWithTools(modelID, messages, nil, modelParams)
 }
 
-func (c *Client) ChatWithTools(modelID string, messages []Message, tools []Tool) (*ChatResponse, error) {
+func (c *Client) ChatWithTools(modelID string, messages []Message, tools []Tool, modelParams *ModelParameters) (*ChatResponse, error) {
 	var url string
 	if strings.HasPrefix(modelID, "@cf/") {
 		url = fmt.Sprintf("%s/accounts/%s/ai/run/%s", c.BaseURL, c.AccountID, modelID)
@@ -60,6 +60,10 @@ func (c *Client) ChatWithTools(modelID string, messages []Message, tools []Tool)
 		Messages: messages,
 		Tools:    tools,
 		Stream:   false,
+	}
+
+	if modelParams != nil {
+		request.ModelParameters = *modelParams
 	}
 
 	jsonData, err := json.Marshal(request)

--- a/workers-ai/types.go
+++ b/workers-ai/types.go
@@ -152,10 +152,10 @@ func (cr *ChatResponse) UnmarshalJSON(data []byte) error {
 
 	// Define a probe struct to detect the format of the 'result' field.
 	type ResultProbe struct {
-		Choices   *json.RawMessage `json:"choices"` // Check for presence of 'choices'
+		Choices   *json.RawMessage `json:"choices,omitempty"` // Check for presence of 'choices'
 		ToolCalls *[]struct {
 			ID string `json:"id"` // Check for presence of 'id' in tool_calls
-		} `json:"tool_calls"`
+		} `json:"tool_calls,omitempty"`
 	}
 
 	var probe ResultProbe
@@ -198,11 +198,38 @@ func (cr *ChatResponse) UnmarshalJSON(data []byte) error {
 }
 
 // ChatCompletionRequest is the complete payload sent to the Chat Completions API.
+//
+// Is the same as the generated type in the cloudflare Go library
+// https://github.com/cloudflare/cloudflare-go/blob/d3656062198c1276336e9a0f2d191c8bb5e0ef89/ai/ai.go#L561
 type ChatCompletionRequest struct {
 	Model    string    `json:"model"`
 	Messages []Message `json:"messages"` // Can contain ChatMessage or ToolMessage.
 	Tools    []Tool    `json:"tools,omitempty"`
 	Stream   bool      `json:"stream,omitempty"`
+	ModelParameters
+}
+
+// Parameters to be set in the ChatCompletionRequest
+type ModelParameters struct {
+	// The maximum number of tokens to generate in the response.
+	MaxTokens int64 `json:"max_tokens,omitempty"`
+
+	// The top_k parameter filters these possibilities, keeping only the top k most likely tokens.
+	// For example, if top_k is set to 10, the model will only consider the 10 most probable tokens when deciding what to output nex
+	//
+	// Should not be used in conjuction with TopP
+	TopK int `json:"top_k,omitempty"`
+
+	// Controls the randomness of the output; higher values produce more random results.
+	Temperature float64 `json:"temperature,omitempty"`
+
+	// A lower top-p value (e.g., 0.2) will result in a smaller, more focused set of tokens,
+	// leading to more predictable and deterministic output.
+	// A higher top-p value (e.g., 0.9) will include a broader range of tokens,
+	// potentially leading to more creative and diverse output, but potentially at the cost of coherence.
+	//
+	// Should not be used in conjuction with TopK
+	TopP float64 `json:"top_p,omitempty"`
 }
 
 // UnmarshalJSON provides custom unmarshaling logic for the ChatCompletionRequest.

--- a/workers-ai/types_test.go
+++ b/workers-ai/types_test.go
@@ -113,9 +113,10 @@ func TestChatResponse_UnmarshalJSON(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "should handle response in JSON object",
-			inputJSON:   `{"result":{"response":{"server_id":"foobar","hello":"world"},"tool_calls":[],"usage":{"prompt_tokens":15061,"completion_tokens":192,"total_tokens":15253}},"success":true,"errors":[],"messages":[]}`,
-			expectError: false,
+			name:         "should handle response in JSON object",
+			inputJSON:    `{"result":{"response":{"server_id":"foobar","hello":"world"},"tool_calls":[],"usage":{"prompt_tokens":15061,"completion_tokens":192,"total_tokens":15253}},"success":true,"errors":[],"messages":[]}`,
+			expectError:  false,
+			expectLegacy: true,
 		},
 	}
 


### PR DESCRIPTION
this enables clients to specify the temperature, top_k, top_p, maxtoken values for a chat request